### PR TITLE
xenstored: use public_names of libraries for the build

### DIFF
--- a/xenstored/dune
+++ b/xenstored/dune
@@ -5,10 +5,10 @@
  (package xenstored)
  (libraries
   unix
-  xenbus
-  xenmmap
-  xenctrl
-  xeneventchn
+  xen.bus
+  xen.mmap
+  xen.ctrl
+  xen.eventchn
   xenstubs))
 
 


### PR DESCRIPTION
This allows `opam pin .` and `dune build -p $name` to work properly

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>